### PR TITLE
fix: changeset use write token to create pr

### DIFF
--- a/.github/workflows/global-release-changeset.yml
+++ b/.github/workflows/global-release-changeset.yml
@@ -60,5 +60,5 @@ jobs:
           version: pnpm changeset version # The command to run to bump the version
           createGithubReleases: true # Set this to true if you want to create a GitHub release
         env:
-          GITHUB_TOKEN: ${{ secrets.LUFA_CI_SECRET_READ }}
+          GITHUB_TOKEN: ${{ secrets.LUFA_CI_SECRET_WRITE }}
           NPM_TOKEN: ${{ secrets.LUFA_CI_SECRET_WRITE }}


### PR DESCRIPTION
This pull request makes a small but important change to the GitHub Actions workflow configuration, updating the permissions for the `GITHUB_TOKEN` used in the release process.

- The workflow in `.github/workflows/global-release-changeset.yml` now uses `LUFA_CI_SECRET_WRITE` for `GITHUB_TOKEN` instead of `LUFA_CI_SECRET_READ`, ensuring that the workflow has write access needed for creating GitHub releases.