### PR TITLE
fix(changeset): set persist-credentials to false

### DIFF
--- a/.github/workflows/global-release-changeset.yml
+++ b/.github/workflows/global-release-changeset.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.LUFA_CI_SECRET_READ }}
+          persist-credentials: false
 
       # Setup using composite action (partial - manual install due to npmrc config)
       - name: Install pnpm


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The change disables credential persistence when checking out the repository, which can improve security for subsequent workflow steps.