### PR TITLE
feat: Clarify changeset rules and add local flag for lufa-agents-sync

### DIFF
--- a/.changeset/update-changeset-grouping-rules.md
+++ b/.changeset/update-changeset-grouping-rules.md
@@ -1,5 +1,21 @@
 ---
-"@grasdouble/lufa_config_agents": patch
+"@grasdouble/lufa_config_agents": minor
+---
+
+feat: add `--local <path>` flag to `lufa-agents-sync` for local iteration
+
+When developing changes to `AGENTS.shared.md`, you can now point the CLI at a
+local clone of Lufa-Core instead of the published npm version:
+
+```bash
+pnpm sync:agents --local ../Lufa-Core
+# or with an absolute path
+lufa-agents-sync --local /path/to/Lufa-Core
+```
+
+The injected block will be annotated with `local@<version>` so it's clear the
+content comes from an unpublished local source.
+
 ---
 
 docs: clarify changeset grouping rules — atomic vs independent changes

--- a/.changeset/update-changeset-grouping-rules.md
+++ b/.changeset/update-changeset-grouping-rules.md
@@ -1,0 +1,10 @@
+---
+"@grasdouble/lufa_config_agents": patch
+---
+
+docs: clarify changeset grouping rules — atomic vs independent changes
+
+Replaces the "one changeset per package" rule with a clearer decision model:
+use a shared file when changes are part of the same atomic feature/fix,
+use separate files when packages changed for unrelated reasons.
+Also adds a rule requiring every package with changed files to be covered.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,7 @@ When creating a changeset file manually in `.changeset/`, always use a **descrip
 **Content rules:**
 
 - Always check `rtk git diff main --name-only` first to identify **all** changed packages before writing changesets (assumes `main` is the default branch — adjust if different)
+- **Every package with changed files must be covered** — do not skip secondary packages (tests, storybook, docs…); if their files changed, they need a changeset entry
 - Use `patch` for fixes/refactors, `minor` for new user-visible features, `major` for breaking changes
 - **Always prefix the description** with a conventional commit type: `feat:`, `fix:`, `chore:`, `refactor:`, `perf:`, `docs:`, `style:`, `test:`
 - **Always verify** the changeset after creation: `rtk pnpm changeset status`
@@ -210,11 +211,14 @@ rtk git diff main --name-only -- .changeset/  # committed but not merged
 - ✅ Create a new file only when no existing changeset covers the package
 - ❌ Never create a second changeset for the same package in the same branch
 
-**One changeset per package** — never bundle unrelated packages in a single changeset:
+**Atomic vs independent — choose the right grouping:**
 
-- ✅ One file per package when changes are independent
-- ✅ One shared file when a **single atomic change** touches multiple packages together
-- ❌ One file listing several packages with unrelated changes
+When multiple packages change together, decide before creating any file:
+
+- ✅ **One shared file** when all packages changed as part of the **same atomic feature or fix** (e.g. a new component + its tests + its stories)
+- ✅ **One file per package** when packages changed for **unrelated reasons** in the same branch
+- ❌ One file per package when the changes are atomic — this creates unnecessary noise and splits a single story across multiple entries
+- ❌ One shared file listing packages with unrelated changes — misleads readers about what changed and why
 
 Prefix guide:
 

--- a/packages/config/agents/AGENTS.shared.md
+++ b/packages/config/agents/AGENTS.shared.md
@@ -184,6 +184,7 @@ When creating a changeset file manually in `.changeset/`, always use a **descrip
 **Content rules:**
 
 - Always check `rtk git diff main --name-only` first to identify **all** changed packages before writing changesets (assumes `main` is the default branch — adjust if different)
+- **Every package with changed files must be covered** — do not skip secondary packages (tests, storybook, docs…); if their files changed, they need a changeset entry
 - Use `patch` for fixes/refactors, `minor` for new user-visible features, `major` for breaking changes
 - **Always prefix the description** with a conventional commit type: `feat:`, `fix:`, `chore:`, `refactor:`, `perf:`, `docs:`, `style:`, `test:`
 - **Always verify** the changeset after creation: `rtk pnpm changeset status`
@@ -201,11 +202,14 @@ rtk git diff main --name-only -- .changeset/  # committed but not merged
 - ✅ Create a new file only when no existing changeset covers the package
 - ❌ Never create a second changeset for the same package in the same branch
 
-**One changeset per package** — never bundle unrelated packages in a single changeset:
+**Atomic vs independent — choose the right grouping:**
 
-- ✅ One file per package when changes are independent
-- ✅ One shared file when a **single atomic change** touches multiple packages together
-- ❌ One file listing several packages with unrelated changes
+When multiple packages change together, decide before creating any file:
+
+- ✅ **One shared file** when all packages changed as part of the **same atomic feature or fix** (e.g. a new component + its tests + its stories)
+- ✅ **One file per package** when packages changed for **unrelated reasons** in the same branch
+- ❌ One file per package when the changes are atomic — this creates unnecessary noise and splits a single story across multiple entries
+- ❌ One shared file listing packages with unrelated changes — misleads readers about what changed and why
 
 Prefix guide:
 

--- a/packages/config/agents/bin/sync-agents.mjs
+++ b/packages/config/agents/bin/sync-agents.mjs
@@ -9,8 +9,9 @@
  *   <!-- END:AGENTS.shared -->
  *
  * Usage:
- *   pnpm sync:agents          (via "sync:agents": "lufa-agents-sync" in package.json)
+ *   pnpm sync:agents                          (via "sync:agents": "lufa-agents-sync" in package.json)
  *   pnpm dlx @grasdouble/lufa_config_agents
+ *   lufa-agents-sync --local ../Lufa-Core     (use a local clone instead of the published version)
  */
 
 import { readFileSync, writeFileSync, realpathSync } from 'node:fs'
@@ -65,9 +66,33 @@ export function injectSharedBlock(agentsMd, sharedContent, version) {
   return { updated, changed: updated !== agentsMd }
 }
 
+/**
+ * Parses `--local <path>` from argv.
+ * Returns the resolved absolute path if provided, or null.
+ * @returns {string|null}
+ */
+function parseLocalFlag() {
+  const args = process.argv.slice(2)
+  const idx = args.indexOf('--local')
+  if (idx === -1) return null
+  const value = args[idx + 1]
+  if (!value || value.startsWith('--')) {
+    console.error('❌ --local requires a path argument: --local <path-to-lufa-core>')
+    process.exit(1)
+  }
+  return resolve(process.cwd(), value)
+}
+
 function main() {
   const __dirname = dirname(fileURLToPath(import.meta.url))
-  const PACKAGE_DIR = resolve(__dirname, '..')
+  const localOverride = parseLocalFlag()
+
+  // When --local <path> is provided, read AGENTS.shared.md from the local clone.
+  // Otherwise fall back to the copy bundled with the installed/running package.
+  const PACKAGE_DIR = localOverride
+    ? resolve(localOverride, 'packages/config/agents')
+    : resolve(__dirname, '..')
+
   const SHARED_MD = resolve(PACKAGE_DIR, 'AGENTS.shared.md')
   const PACKAGE_JSON = resolve(PACKAGE_DIR, 'package.json')
   const AGENTS_MD = resolve(process.cwd(), 'AGENTS.md')
@@ -83,10 +108,14 @@ function main() {
 
   try {
     const raw = JSON.parse(readFileSync(PACKAGE_JSON, 'utf8')).version
-    // When running from the source repo itself, PACKAGE_DIR is not inside node_modules.
-    // Installed packages always live under node_modules/.pnpm/...
-    const isSourceRepo = !PACKAGE_DIR.includes('node_modules')
-    version = isSourceRepo ? 'local' : raw
+    if (localOverride) {
+      version = `local@${raw}`
+    } else {
+      // When running from the source repo itself, PACKAGE_DIR is not inside node_modules.
+      // Installed packages always live under node_modules/.pnpm/...
+      const isSourceRepo = !PACKAGE_DIR.includes('node_modules')
+      version = isSourceRepo ? 'local' : raw
+    }
   } catch {
     console.error(`❌ Cannot read package.json from ${PACKAGE_JSON}`)
     process.exit(1)


### PR DESCRIPTION
This pull request updates the changeset authoring guidelines for the project, clarifying how to group changes and ensuring all affected packages are properly documented. It also introduces a new CLI flag to improve local development workflow for `lufa-agents-sync`.

**Guideline and documentation improvements:**

* Clarifies changeset grouping rules by replacing the "one changeset per package" rule with a decision model: use a shared changeset file for atomic features/fixes that affect multiple packages, and separate files for unrelated changes. This helps ensure changesets accurately reflect the intent and scope of changes. [[1]](diffhunk://#diff-906aa23b60499f6a600080fbaff06fa9e8e838fa32e2e24fe507567b5b7d6f60R1-R26) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L213-R221) [[3]](diffhunk://#diff-938a94f303a4cccceb0f3d4059222d403fd19f0b3de41181c7ba21589b1fa3c7L204-R212)
* Adds a rule requiring that every package with changed files must be covered by a changeset, including secondary packages like tests, docs, and storybook. [[1]](diffhunk://#diff-906aa23b60499f6a600080fbaff06fa9e8e838fa32e2e24fe507567b5b7d6f60R1-R26) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R196) [[3]](diffhunk://#diff-938a94f303a4cccceb0f3d4059222d403fd19f0b3de41181c7ba21589b1fa3c7R187)

**Developer tooling:**

* Adds a `--local <path>` flag to the `lufa-agents-sync` CLI, allowing developers to sync against a local clone of Lufa-Core for faster iteration. Injected content is annotated as coming from a local, unpublished source.