### PR TITLE
fix: Enhance AGENTS.md and update Vitest configuration

### DIFF
--- a/.changeset/neat-badgers-stick.md
+++ b/.changeset/neat-badgers-stick.md
@@ -1,0 +1,5 @@
+---
+'@grasdouble/lufa_config_agents': patch
+---
+
+fix: Improve AGENTS

--- a/.changeset/rich-snails-sneeze.md
+++ b/.changeset/rich-snails-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@grasdouble/lufa_config_vitest': patch
+---
+
+fix: export js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,8 @@ rtk git status --short .changeset/   # untracked / staged files
 rtk git diff main --name-only -- .changeset/  # committed but not merged
 ```
 
-- ✅ If an existing changeset targets the same package → **add your description to it** (same bump type or escalate)
+- ✅ If an existing changeset targets the **exact same set of packages** you modified → **add your description to it** (same bump type or escalate)
+- ✅ If an existing changeset covers some of your packages but also covers **packages you did not modify** → **create a new file** covering only the packages you changed
 - ✅ Create a new file only when no existing changeset covers the package
 - ❌ Never create a second changeset for the same package in the same branch
 

--- a/packages/config/agents/AGENTS.shared.md
+++ b/packages/config/agents/AGENTS.shared.md
@@ -174,6 +174,34 @@ When writing or reviewing code, if an accessibility issue is found, fix it in th
 
 ---
 
+## TDD — Test before code
+
+When modifying existing code or implementing new behavior, always follow the **Red → Green → Refactor** cycle:
+
+1. **Red** — Write or update the test first, run it, confirm it fails for the right reason
+2. **Green** — Write the minimal code to make the test pass
+3. **Refactor** — Clean up, then re-run tests to confirm they still pass
+
+**Rules:**
+
+- ✅ Write or update the failing test **before** changing the production code
+- ✅ When a code change makes an existing test fail, update the test **before** running the code change — or update both together and confirm the test fails for the right reason first
+- ✅ Run the affected test suite after every step (`pnpm test` in the package folder)
+- ❌ Never write code first and tests after — the test must define expected behavior, not describe existing code
+- ❌ Never leave tests broken and move on — all tests must pass before the task is considered done
+- ❌ Never delete a test to make a suite pass — update it to match the new expected behavior, or justify removal explicitly
+
+**What counts as "a change":**
+
+- Modifying a component's rendered output (elements, attributes, text)
+- Changing a function's signature or return value
+- Adding, removing, or renaming props
+- Changing accessibility attributes (aria, role, alt…)
+
+**Exception:** When adding a brand-new feature with no existing test, write the test file first (even if it just has a skeleton), then implement.
+
+---
+
 ## Changesets — Naming and content
 
 When creating a changeset file manually in `.changeset/`, always use a **descriptive kebab-case name** — never a random hex ID.

--- a/packages/config/agents/AGENTS.shared.md
+++ b/packages/config/agents/AGENTS.shared.md
@@ -202,7 +202,8 @@ rtk git status --short .changeset/   # untracked / staged files
 rtk git diff main --name-only -- .changeset/  # committed but not merged
 ```
 
-- ✅ If an existing changeset targets the same package → **add your description to it** (same bump type or escalate)
+- ✅ If an existing changeset targets the **exact same set of packages** you modified → **add your description to it** (same bump type or escalate)
+- ✅ If an existing changeset covers some of your packages but also covers **packages you did not modify** → **create a new file** covering only the packages you changed
 - ✅ Create a new file only when no existing changeset covers the package
 - ❌ Never create a second changeset for the same package in the same branch
 

--- a/packages/config/vitest/package.json
+++ b/packages/config/vitest/package.json
@@ -10,14 +10,15 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": "./dist/index.js"
   },
   "files": [
-    "index.ts",
+    "dist",
     "README.md",
     "CHANGELOG.md"
   ],
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "lint": "eslint .",
     "prettier:check": "prettier --check .",
     "prettier:write": "prettier --write .",

--- a/packages/config/vitest/tsconfig.build.json
+++ b/packages/config/vitest/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": ["@grasdouble/lufa_config_tsconfig/base.json"],
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
This pull request introduces improvements to both the agents configuration and the vitest config package. It adds new development guidelines, clarifies changeset usage, and updates the build/export setup for the `@grasdouble/lufa_config_vitest` package to export compiled JavaScript instead of TypeScript. The most significant changes are summarized below:

**Development Process and Documentation:**

* Added a new "TDD — Test before code" section to `AGENTS.shared.md`, outlining best practices for test-driven development, including the Red-Green-Refactor cycle and clear rules for when and how to write or update tests.
* Clarified instructions for changeset files in both `AGENTS.md` and `AGENTS.shared.md`, specifying when to add to an existing changeset versus creating a new one, especially when multiple packages are involved. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L214-R215) [[2]](diffhunk://#diff-938a94f303a4cccceb0f3d4059222d403fd19f0b3de41181c7ba21589b1fa3c7L205-R234)

**Build and Export Configuration for Vitest Config Package:**

* Updated `package.json` in `@grasdouble/lufa_config_vitest` to export the compiled JavaScript file from `dist/index.js` instead of the TypeScript source, and adjusted the `files` field accordingly. Also added a `build` script for TypeScript compilation.
* Added a new `tsconfig.build.json` to configure TypeScript for building the package, specifying output directory and compiler options.

**Changeset Tracking:**

* Added changeset files to record and describe the above fixes and improvements for both `@grasdouble/lufa_config_agents` and `@grasdouble/lufa_config_vitest`. [[1]](diffhunk://#diff-49ebd0705aadb5cb42631f820f0db8b262b8568c6465f9175ab51ad6379a2469R1-R5) [[2]](diffhunk://#diff-651e80b43cee7a7b02f63f665365510c68a82fc513d4d156075d43ad6a50bffdR1-R5)